### PR TITLE
Change inferencing command from predict() to __call__()

### DIFF
--- a/test.py
+++ b/test.py
@@ -79,7 +79,7 @@ with open(cfg.TEST.ANNOT_PATH, 'r') as annotation_file:
         image_data = utils.image_preporcess(np.copy(image), [INPUT_SIZE, INPUT_SIZE])
         image_data = image_data[np.newaxis, ...].astype(np.float32)
 
-        pred_bbox = model.predict(image_data)
+        pred_bbox = model(image_data)
         pred_bbox = [tf.reshape(x, (-1, tf.shape(x)[-1])) for x in pred_bbox]
         pred_bbox = tf.concat(pred_bbox, axis=0)
         bboxes = utils.postprocess_boxes(pred_bbox, image_size, INPUT_SIZE, cfg.TEST.SCORE_THRESHOLD)


### PR DESCRIPTION
I faced an issue that the model provided predictions for the first image, but no predictions for the rest. I managed to fix it by changing the inferencing command from `predict()` to `__call__()`.

Note:
I'm using tensorflow 2.9.1
Here are some details about the difference between the two inferencing methods:
https://www.tensorflow.org/api_docs/python/tf/keras/Model#predict